### PR TITLE
Correctly serialize ImmutableRoaringBitmap 

### DIFF
--- a/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringArray.java
+++ b/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringArray.java
@@ -230,7 +230,7 @@ public final class ImmutableRoaringArray implements PointableRoaringArray {
      */
     public void serialize(DataOutput out) throws IOException {
         if(buffer.hasArray()) {
-            out.write(buffer.array());
+            out.write(buffer.array(), buffer.arrayOffset(), buffer.limit());
         } else {
             ByteBuffer tmp = buffer.duplicate();
             tmp.position(0);


### PR DESCRIPTION
It was writing the entire backing array even if the ByteBuffer only covered part of the array.