### PR TITLE
#36 add andCardinality method that does not modify input RoaringBitSet

### DIFF
--- a/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -87,15 +87,12 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
      * modified. This operation is thread-safe as long as the provided
      * bitmaps remain unchanged.
      *
-     * If you have more than 2 bitmaps, consider using the
-     * FastAggregation class.
-     *
      * @param x1 first bitmap
      * @param x2 other bitmap
      * @return as if you did and(x2,x2).getCardinality()
      * @see FastAggregation#and(RoaringBitmap...)
      */
-    public static int andCount(final RoaringBitmap x1,
+    public static int andCardinality(final RoaringBitmap x1,
                                     final RoaringBitmap x2) {
         int answer = 0;
         final int length1 = x1.highLowContainer.size(), length2 = x2.highLowContainer.size();

--- a/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -82,6 +82,44 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
     }
 
     /**
+     * Cardinality of Bitwise AND (intersection) operation. 
+     * The provided bitmaps are *not* 
+     * modified. This operation is thread-safe as long as the provided
+     * bitmaps remain unchanged.
+     *
+     * If you have more than 2 bitmaps, consider using the
+     * FastAggregation class.
+     *
+     * @param x1 first bitmap
+     * @param x2 other bitmap
+     * @return as if you did and(x2,x2).getCardinality()
+     * @see FastAggregation#and(RoaringBitmap...)
+     */
+    public static int andCount(final RoaringBitmap x1,
+                                    final RoaringBitmap x2) {
+        int answer = 0;
+        final int length1 = x1.highLowContainer.size(), length2 = x2.highLowContainer.size();
+        int pos1 = 0, pos2 = 0;
+
+        while (pos1 < length1 && pos2 < length2) {
+            final short s1 = x1.highLowContainer.getKeyAtIndex(pos1);
+            final short s2 = x2.highLowContainer.getKeyAtIndex(pos2);
+            if (s1 == s2) {
+                final Container c1 = x1.highLowContainer.getContainerAtIndex(pos1);
+                final Container c2 = x2.highLowContainer.getContainerAtIndex(pos2);
+                final Container c = c1.and(c2);
+                answer += c.getCardinality();
+                ++pos1;
+                ++pos2;
+            } else if (Util.compareUnsigned(s1, s2) < 0) { // s1 < s2
+                pos1 = x1.highLowContainer.advanceUntil(s2,pos1);
+            } else { // s1 > s2
+                pos2 = x2.highLowContainer.advanceUntil(s1,pos2);
+            }
+        }
+        return answer;
+    }
+    /**
      * Bitwise ANDNOT (difference) operation. The provided bitmaps are *not*
      * modified. This operation is thread-safe as long as the provided
      * bitmaps remain unchanged.

--- a/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -3670,7 +3670,7 @@ public class TestRoaringBitmap {
         }
 
         final RoaringBitmap rrand = RoaringBitmap.and(rr, rr2);
-        final int rrandCount = RoaringBitmap.andCount(rr, rr2);
+        final int rrandCount = RoaringBitmap.andCardinality(rr, rr2);
 
         Assert.assertEquals(rrand.getCardinality(), rrandCount);
     }
@@ -3687,9 +3687,9 @@ public class TestRoaringBitmap {
         final RoaringBitmap rr2 = new RoaringBitmap();
         rr2.add(13);
         final RoaringBitmap rrand = RoaringBitmap.and(rr, rr2);
-        assertEquals(rrand.getCardinality(), RoaringBitmap.andCount(rr, rr2));
-        assertEquals(rrand.getCardinality(), RoaringBitmap.andCount(rr2, rr));
+        assertEquals(rrand.getCardinality(), RoaringBitmap.andCardinality(rr, rr2));
+        assertEquals(rrand.getCardinality(), RoaringBitmap.andCardinality(rr2, rr));
         rr.and(rr2);
-        assertEquals(rrand.getCardinality(), RoaringBitmap.andCount(rr2, rr));
+        assertEquals(rrand.getCardinality(), RoaringBitmap.andCardinality(rr2, rr));
     }
 }

--- a/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -3619,4 +3619,77 @@ public class TestRoaringBitmap {
         assertEquals(182, bitmap.getCardinality());
     }
 
+    
+    @Test
+    public void andCounttest3() {
+    	//This is based on andtest3
+        final int[] arrayand = new int[11256];
+        int pos = 0;
+        final RoaringBitmap rr = new RoaringBitmap();
+        for (int k = 4000; k < 4256; ++k)
+            rr.add(k);
+        for (int k = 65536; k < 65536 + 4000; ++k)
+            rr.add(k);
+        for (int k = 3 * 65536; k < 3 * 65536 + 1000; ++k)
+            rr.add(k);
+        for (int k = 3 * 65536 + 1000; k < 3 * 65536 + 7000; ++k)
+            rr.add(k);
+        for (int k = 3 * 65536 + 7000; k < 3 * 65536 + 9000; ++k)
+            rr.add(k);
+        for (int k = 4 * 65536; k < 4 * 65536 + 7000; ++k)
+            rr.add(k);
+        for (int k = 6 * 65536; k < 6 * 65536 + 10000; ++k)
+            rr.add(k);
+        for (int k = 8 * 65536; k < 8 * 65536 + 1000; ++k)
+            rr.add(k);
+        for (int k = 9 * 65536; k < 9 * 65536 + 30000; ++k)
+            rr.add(k);
+
+        final RoaringBitmap rr2 = new RoaringBitmap();
+        for (int k = 4000; k < 4256; ++k) {
+            rr2.add(k);
+            arrayand[pos++] = k;
+        }
+        for (int k = 65536; k < 65536 + 4000; ++k) {
+            rr2.add(k);
+            arrayand[pos++] = k;
+        }
+        for (int k = 3 * 65536 + 1000; k < 3 * 65536 + 7000; ++k) {
+            rr2.add(k);
+            arrayand[pos++] = k;
+        }
+        for (int k = 6 * 65536; k < 6 * 65536 + 1000; ++k) {
+            rr2.add(k);
+            arrayand[pos++] = k;
+        }
+        for (int k = 7 * 65536; k < 7 * 65536 + 1000; ++k) {
+            rr2.add(k);
+        }
+        for (int k = 10 * 65536; k < 10 * 65536 + 5000; ++k) {
+            rr2.add(k);
+        }
+
+        final RoaringBitmap rrand = RoaringBitmap.and(rr, rr2);
+        final int rrandCount = RoaringBitmap.andCount(rr, rr2);
+
+        Assert.assertEquals(rrand.getCardinality(), rrandCount);
+    }
+    
+    @Test
+    public void andcounttest() {
+    	//This is based on andtest
+        final RoaringBitmap rr = new RoaringBitmap();
+        for (int k = 0; k < 4000; ++k) {
+            rr.add(k);
+        }
+        rr.add(100000);
+        rr.add(110000);
+        final RoaringBitmap rr2 = new RoaringBitmap();
+        rr2.add(13);
+        final RoaringBitmap rrand = RoaringBitmap.and(rr, rr2);
+        assertEquals(rrand.getCardinality(), RoaringBitmap.andCount(rr, rr2));
+        assertEquals(rrand.getCardinality(), RoaringBitmap.andCount(rr2, rr));
+        rr.and(rr2);
+        assertEquals(rrand.getCardinality(), RoaringBitmap.andCount(rr2, rr));
+    }
 }


### PR DESCRIPTION
As I have a similar issue as #36 with requiring a lot of intersect counts and wishing to avoid the cost of allocation I implemented the basic andCardinality method.

The logic is shamelessly stolen from the and method. The only difference is that only an int is incremented instead of a new RoaringBitSet build as are the two test cases.


