### PR TITLE
#36 andCardinality methods added to the Containers avoiding materialization

### DIFF
--- a/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -123,12 +123,9 @@ public final class ArrayContainer extends Container implements Cloneable {
 
     @Override
     public int andCardinality(final ArrayContainer value2) {
-        ArrayContainer value1 = this;
-        int desiredCardinality = Math.min(value1.getCardinality(), value2.getCardinality());
-        if (0 == desiredCardinality)
-            return 0;
-        //TODO this should be replaced by a non allocating algorithm.
-        return and(value2).cardinality;
+        return Util.unsignedLocalIntersect2by2Cardinality(content,
+                cardinality, value2.content,
+                value2.getCardinality());
     }
     
     @Override

--- a/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -124,11 +124,11 @@ public final class ArrayContainer extends Container implements Cloneable {
     @Override
     public int andCardinality(final ArrayContainer value2) {
         ArrayContainer value1 = this;
-        final int desiredCapacity = Math.min(value1.getCardinality(), value2.getCardinality());
-        ArrayContainer answer = new ArrayContainer(desiredCapacity);
-        return Util.unsignedIntersect2by2(value1.content,
-                value1.getCardinality(), value2.content,
-                value2.getCardinality(), answer.content);
+        int desiredCardinality = Math.min(value1.getCardinality(), value2.getCardinality());
+        if (0 == desiredCardinality)
+            return 0;
+        //TODO this should be replaced by a non allocating algorithm.
+        return and(value2).cardinality;
     }
     
     @Override

--- a/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -122,10 +122,25 @@ public final class ArrayContainer extends Container implements Cloneable {
     }
 
     @Override
+    public int andCardinality(final ArrayContainer value2) {
+        ArrayContainer value1 = this;
+        final int desiredCapacity = Math.min(value1.getCardinality(), value2.getCardinality());
+        ArrayContainer answer = new ArrayContainer(desiredCapacity);
+        return Util.unsignedIntersect2by2(value1.content,
+                value1.getCardinality(), value2.content,
+                value2.getCardinality(), answer.content);
+    }
+    
+    @Override
     public Container and(BitmapContainer x) {
         return x.and(this);
     }
 
+    @Override
+    public int andCardinality(BitmapContainer x) {
+        return x.andCardinality(this);
+    }
+    
     @Override
     public ArrayContainer andNot(final ArrayContainer value2) {
         ArrayContainer value1 = this;
@@ -872,6 +887,12 @@ public final class ArrayContainer extends Container implements Cloneable {
         return x.and(this);
     }
 
+    @Override
+    // see andNot for an approach that might be better.
+    public int andCardinality(RunContainer x) {
+        return x.andCardinality(this);
+    }
+    
     @Override
     public Container andNot(RunContainer x) {
         int writeLocation=0;

--- a/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -232,16 +232,7 @@ public final class BitmapContainer extends Container implements Cloneable {
             newCardinality += Long.bitCount(this.bitmap[k]
                     & value2.bitmap[k]);
         }
-        if (newCardinality > ArrayContainer.DEFAULT_MAX_SIZE) {
-            final BitmapContainer answer = new BitmapContainer();
-            for (int k = 0; k < answer.bitmap.length; ++k) {
-                answer.bitmap[k] = this.bitmap[k]
-                        & value2.bitmap[k];
-            }
-            return newCardinality;
-        } else {
-        	return newCardinality;
-        }
+        return newCardinality;
     }
     
     @Override

--- a/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -191,6 +191,18 @@ public final class BitmapContainer extends Container implements Cloneable {
         }
         return answer;
     }
+    
+    @Override
+    public int andCardinality(final ArrayContainer value2) {
+        int answer=0;
+        int c = value2.cardinality;
+        for (int k = 0; k < c; ++k) {
+            short v = value2.content[k];
+            if (this.contains(v))
+                answer++;
+        }
+        return answer;
+    }
 
     @Override
     public Container and(final BitmapContainer value2) {
@@ -213,7 +225,25 @@ public final class BitmapContainer extends Container implements Cloneable {
         ac.cardinality = newCardinality;
         return ac;
     }
-
+    @Override
+    public int andCardinality(final BitmapContainer value2) {
+        int newCardinality = 0;
+        for (int k = 0; k < this.bitmap.length; ++k) {
+            newCardinality += Long.bitCount(this.bitmap[k]
+                    & value2.bitmap[k]);
+        }
+        if (newCardinality > ArrayContainer.DEFAULT_MAX_SIZE) {
+            final BitmapContainer answer = new BitmapContainer();
+            for (int k = 0; k < answer.bitmap.length; ++k) {
+                answer.bitmap[k] = this.bitmap[k]
+                        & value2.bitmap[k];
+            }
+            return newCardinality;
+        } else {
+        	return newCardinality;
+        }
+    }
+    
     @Override
     public Container andNot(final ArrayContainer value2) {
         final BitmapContainer answer = clone();
@@ -1054,6 +1084,11 @@ public final class BitmapContainer extends Container implements Cloneable {
     @Override
     public Container and(RunContainer x) {
         return x.and(this);
+    }
+    
+    @Override
+    public int andCardinality(RunContainer x) {
+        return x.andCardinality(this);
     }
 
     @Override

--- a/src/main/java/org/roaringbitmap/Container.java
+++ b/src/main/java/org/roaringbitmap/Container.java
@@ -99,6 +99,32 @@ public abstract class Container implements Iterable<Short>, Cloneable, Externali
     }
 
     /**
+     * Computes the bitwise AND of this container with another
+     * (intersection). This container as well as the provided container are
+     * left unaffected.
+     *
+     * @param x other container
+     * @return aggregated container
+     */
+    public int andCardinality(Container x) {
+    	if (this.getCardinality() == 0)
+    		return 0;
+    	else if (x.getCardinality() ==0)
+    		return 0;
+		else
+		{
+    		if (x instanceof ArrayContainer)
+            	return and((ArrayContainer) x).getCardinality();
+        	else if (x instanceof BitmapContainer)
+            	return and((BitmapContainer) x).getCardinality();
+        	return and((RunContainer) x).getCardinality();
+    	}
+    }
+    
+    public abstract int andCardinality(ArrayContainer x);
+    public abstract int andCardinality(BitmapContainer x);
+    public abstract int andCardinality(RunContainer x);
+    /**
      * Computes the bitwise ANDNOT of this container with another
      * (difference). This container as well as the provided container are
      * left unaffected.

--- a/src/main/java/org/roaringbitmap/Container.java
+++ b/src/main/java/org/roaringbitmap/Container.java
@@ -107,18 +107,17 @@ public abstract class Container implements Iterable<Short>, Cloneable, Externali
      * @return aggregated container
      */
     public int andCardinality(Container x) {
-    	if (this.getCardinality() == 0)
-    		return 0;
-    	else if (x.getCardinality() ==0)
-    		return 0;
-		else
-		{
-    		if (x instanceof ArrayContainer)
-            	return and((ArrayContainer) x).getCardinality();
-        	else if (x instanceof BitmapContainer)
-            	return and((BitmapContainer) x).getCardinality();
-        	return and((RunContainer) x).getCardinality();
-    	}
+        if (this.getCardinality() == 0)
+            return 0;
+        else if (x.getCardinality() == 0)
+            return 0;
+        else {
+            if (x instanceof ArrayContainer)
+                return andCardinality((ArrayContainer) x);
+            else if (x instanceof BitmapContainer)
+                return andCardinality((BitmapContainer) x);
+            return andCardinality((RunContainer) x);
+        }
     }
     
     public abstract int andCardinality(ArrayContainer x);

--- a/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -104,9 +104,8 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
             if (s1 == s2) {
                 final Container c1 = x1.highLowContainer.getContainerAtIndex(pos1);
                 final Container c2 = x2.highLowContainer.getContainerAtIndex(pos2);
-                final Container c = c1.and(c2);
                 // TODO: could be made faster if we did not have to materialize container
-                answer += c.getCardinality();
+                answer += c1.andCardinality(c2);
                 ++pos1;
                 ++pos2;
             } else if (Util.compareUnsigned(s1, s2) < 0) { // s1 < s2

--- a/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/src/main/java/org/roaringbitmap/RunContainer.java
@@ -4,7 +4,11 @@
  */
 package org.roaringbitmap;
 
-import java.io.*;
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.util.Arrays;
 import java.util.Iterator;
 
@@ -525,34 +529,17 @@ public final class RunContainer extends Container implements Cloneable {
     @Override
     public int andCardinality(BitmapContainer x) {
         // could be implemented as return toBitmapOrArrayContainer().iand(x);
-        int card = this.getCardinality();
         int cardinality=0;
-        if (card <=  ArrayContainer.DEFAULT_MAX_SIZE) {
-            // result can only be an array (assuming that we never make a RunContainer)
-            if(card > x.cardinality) card = x.cardinality;
-            cardinality=0;
-            for (int rlepos=0; rlepos < this.nbrruns; ++rlepos) {
-                int runStart = Util.toIntUnsigned(this.getValue(rlepos));
-                int runEnd = runStart + Util.toIntUnsigned(this.getLength(rlepos));
-                for (int runValue = runStart; runValue <= runEnd; ++runValue) {
-                    if ( x.contains((short) runValue)) {// it looks like contains() should be cheap enough if accessed sequentially
-                        cardinality++;
-                    }
+        for (int rlepos=0; rlepos < this.nbrruns; ++rlepos) {
+            int runStart = Util.toIntUnsigned(this.getValue(rlepos));
+            int runEnd = runStart + Util.toIntUnsigned(this.getLength(rlepos));
+            for (int runValue = runStart; runValue <= runEnd; ++runValue) {
+                if ( x.contains((short) runValue)) {// it looks like contains() should be cheap enough if accessed sequentially
+                    cardinality++;
                 }
             }
-            return cardinality;
         }
-        // we expect the answer to be a bitmap (if we are lucky)
-        BitmapContainer answer = x.clone();
-        int start = 0;
-        for(int rlepos = 0; rlepos < this.nbrruns; ++rlepos ) {
-            int end = Util.toIntUnsigned(this.getValue(rlepos));
-            Util.resetBitmapRange(answer.bitmap, start, end);  // had been x.bitmap
-            start = end + Util.toIntUnsigned(this.getLength(rlepos)) + 1;
-        }
-        Util.resetBitmapRange(answer.bitmap, start, Util.maxLowBitAsInteger() + 1);   // had been x.bitmap
-        answer.computeCardinality();
-        return answer.getCardinality();
+        return cardinality;
     }
 
     @Override
@@ -1699,73 +1686,8 @@ public final class RunContainer extends Container implements Cloneable {
 
     @Override
     public int andCardinality(RunContainer x) {
-      int answer = 0;
-      int rlepos = 0;
-      int xrlepos = 0;
-      int start = Util.toIntUnsigned(this.getValue(rlepos));
-      int end = start + Util.toIntUnsigned(this.getLength(rlepos)) + 1;
-      int xstart = Util.toIntUnsigned(x.getValue(xrlepos));
-      int xend = xstart + Util.toIntUnsigned(x.getLength(xrlepos)) + 1;
-      while ((rlepos < this.nbrruns ) && (xrlepos < x.nbrruns )) {
-          if (end  <= xstart) {
-              if (ENABLE_GALLOPING_AND) {
-                  rlepos = skipAhead(this, rlepos, xstart); // skip over runs until we have end > xstart  (or rlepos is advanced beyond end)
-              }
-              else
-                  ++rlepos;
-
-              if(rlepos < this.nbrruns ) {
-                  start = Util.toIntUnsigned(this.getValue(rlepos));
-                  end = start + Util.toIntUnsigned(this.getLength(rlepos)) + 1;
-              }
-          } else if (xend <= start) {
-              // exit the second run
-              if (ENABLE_GALLOPING_AND) {
-                  xrlepos = skipAhead(x, xrlepos, start);
-              }
-              else
-                  ++xrlepos;
-
-              if(xrlepos < x.nbrruns ) {
-                  xstart = Util.toIntUnsigned(x.getValue(xrlepos));
-                  xend = xstart + Util.toIntUnsigned(x.getLength(xrlepos)) + 1;
-              }
-          } else {// they overlap
-              final int lateststart = start > xstart ? start : xstart;
-              int earliestend;
-              if(end == xend) {// improbable
-                  earliestend = end;
-                  rlepos++;
-                  xrlepos++;
-                  if(rlepos < this.nbrruns ) {
-                      start = Util.toIntUnsigned(this.getValue(rlepos));
-                      end = start + Util.toIntUnsigned(this.getLength(rlepos)) + 1;
-                  }
-                  if(xrlepos < x.nbrruns) {
-                      xstart = Util.toIntUnsigned(x.getValue(xrlepos));
-                      xend = xstart + Util.toIntUnsigned(x.getLength(xrlepos)) + 1;
-                  }
-              } else if(end < xend) {
-                  earliestend = end;
-                  rlepos++;
-                  if(rlepos < this.nbrruns ) {
-                      start = Util.toIntUnsigned(this.getValue(rlepos));
-                      end = start + Util.toIntUnsigned(this.getLength(rlepos)) + 1;
-                  }
-
-              } else {// end > xend
-                  earliestend = xend;
-                  xrlepos++;
-                  if(xrlepos < x.nbrruns) {
-                      xstart = Util.toIntUnsigned(x.getValue(xrlepos));
-                      xend = xstart + Util.toIntUnsigned(x.getLength(xrlepos)) + 1;
-                  }                
-              }
-              answer = answer + Util.toIntUnsigned(getLength((short) lateststart));
-              answer = answer + Util.toIntUnsigned(getLength((short) (earliestend - lateststart - 1)));
-          }
-      }
-      return answer;  // subsequent trim() may be required to avoid wasted space.
+        //TODO replace this by non allocating method
+        return and(x).getCardinality();
   }
 
 

--- a/src/main/java/org/roaringbitmap/Util.java
+++ b/src/main/java/org/roaringbitmap/Util.java
@@ -492,6 +492,52 @@ public final class Util {
         }
         return pos;
     }
+    
+    protected static int unsignedLocalIntersect2by2Cardinality(final short[] set1, final int length1,
+            final short[] set2, final int length2) {
+        if ((0 == length1) || (0 == length2))
+            return 0;
+        int k1 = 0;
+        int k2 = 0;
+        int pos = 0;
+        short s1 = set1[k1];
+        short s2 = set2[k2];
+
+        mainwhile: while (true) {
+            int v1 = toIntUnsigned(s1);
+            int v2 = toIntUnsigned(s2);
+            if (v2 < v1) {
+                do {
+                    ++k2;
+                    if (k2 == length2)
+                        break mainwhile;
+                    s2 = set2[k2];
+                    v2 = toIntUnsigned(s2);
+                } while (v2 < v1);
+            }
+            if (v1 < v2) {
+                do {
+                    ++k1;
+                    if (k1 == length1)
+                        break mainwhile;
+                    s1 = set1[k1];
+                    v1 = toIntUnsigned(s1);
+                } while (v1 < v2);
+            } else {
+                // (set2[k2] == set1[k1])
+                pos++;
+                ++k1;
+                if (k1 == length1)
+                    break;
+                ++k2;
+                if (k2 == length2)
+                    break;
+                s1 = set1[k1];
+                s2 = set2[k2];
+            }
+        }
+        return pos;
+    }
 
     protected static int unsignedOneSidedGallopingIntersect2by2(
             final short[] smallSet, final int smallLength,

--- a/src/test/java/org/roaringbitmap/TestContainer.java
+++ b/src/test/java/org/roaringbitmap/TestContainer.java
@@ -857,13 +857,13 @@ public class TestContainer {
         }
     }
 
-    private final static Class[] CONTAINER_TYPES = new Class[] { ArrayContainer.class, BitmapContainer.class, RunContainer.class};
+    private final static Class<?>[] CONTAINER_TYPES = new Class[] { ArrayContainer.class, BitmapContainer.class, RunContainer.class};
 	@Test
 	public void and1()
 	    throws InstantiationException, IllegalAccessException
 	{
 		System.out.println("and1");
-		for (Class ct : CONTAINER_TYPES)
+		for (Class<?> ct : CONTAINER_TYPES)
 		{
 			Container ac = (Container) ct.newInstance();
 			ac.add((short) 1);
@@ -871,7 +871,7 @@ public class TestContainer {
 			ac.add((short) 5);
 			ac.add((short) 50000);
 			ac.add((short) 50001);
-			for (Class ct1 : CONTAINER_TYPES)
+			for (Class<?> ct1 : CONTAINER_TYPES)
 			{
 				Container ac1 = (Container) ct1.newInstance();
 				Container result = ac.and(ac1);
@@ -888,11 +888,11 @@ public class TestContainer {
 	    throws InstantiationException, IllegalAccessException
 	{
 		System.out.println("and2");
-		for (Class ct : CONTAINER_TYPES)
+		for (Class<?> ct : CONTAINER_TYPES)
 		{
 			Container ac = (Container) ct.newInstance();
 			ac.add((short) 1);
-			for (Class ct1 : CONTAINER_TYPES)
+			for (Class<?> ct1 : CONTAINER_TYPES)
 			{
 				Container ac1 = (Container) ct1.newInstance();
 
@@ -921,7 +921,7 @@ public class TestContainer {
 	    throws InstantiationException, IllegalAccessException
 	{
 		System.out.println("and3");
-		for (Class ct : CONTAINER_TYPES)
+		for (Class<?> ct : CONTAINER_TYPES)
 		{
 			Container ac = (Container) ct.newInstance();
 
@@ -933,7 +933,7 @@ public class TestContainer {
 
 			// array ends first
 
-			for (Class ct1 : CONTAINER_TYPES)
+			for (Class<?> ct1 : CONTAINER_TYPES)
 			{
 				Container ac1 = (Container) ct1.newInstance();
 
@@ -961,7 +961,7 @@ public class TestContainer {
 	    throws InstantiationException, IllegalAccessException
 	{
 		System.out.println("and4");
-		for (Class ct : CONTAINER_TYPES)
+		for (Class<?> ct : CONTAINER_TYPES)
 		{
 			Container ac = (Container) ct.newInstance();
 
@@ -974,7 +974,7 @@ public class TestContainer {
 
 			// iterator ends first
 
-			for (Class ct1 : CONTAINER_TYPES)
+			for (Class<?> ct1 : CONTAINER_TYPES)
 			{
 				Container ac1 = (Container) ct1.newInstance();
 
@@ -1002,7 +1002,7 @@ public class TestContainer {
 	    throws InstantiationException, IllegalAccessException
 	{
 		System.out.println("and5");
-		for (Class ct : CONTAINER_TYPES)
+		for (Class<?> ct : CONTAINER_TYPES)
 		{
 			Container ac = (Container) ct.newInstance();
 
@@ -1014,7 +1014,7 @@ public class TestContainer {
 
 			// end together
 
-			for (Class ct1 : CONTAINER_TYPES)
+			for (Class<?> ct1 : CONTAINER_TYPES)
 			{
 				Container ac1 = (Container) ct1.newInstance();
 

--- a/src/test/java/org/roaringbitmap/TestContainer.java
+++ b/src/test/java/org/roaringbitmap/TestContainer.java
@@ -5,15 +5,15 @@
 package org.roaringbitmap;
 
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Random;
-import java.util.ArrayList;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertSame;
+import org.junit.Test;
 
 /**
  * Various tests on Container and its subclasses, ArrayContainer and
@@ -857,7 +857,177 @@ public class TestContainer {
         }
     }
 
+    private final static Class[] CONTAINER_TYPES = new Class[] { ArrayContainer.class, BitmapContainer.class, RunContainer.class};
+	@Test
+	public void and1()
+	    throws InstantiationException, IllegalAccessException
+	{
+		System.out.println("and1");
+		for (Class ct : CONTAINER_TYPES)
+		{
+			Container ac = (Container) ct.newInstance();
+			ac.add((short) 1);
+			ac.add((short) 3);
+			ac.add((short) 5);
+			ac.add((short) 50000);
+			ac.add((short) 50001);
+			for (Class ct1 : CONTAINER_TYPES)
+			{
+				Container ac1 = (Container) ct1.newInstance();
+				Container result = ac.and(ac1);
+				assertTrue(checkContent(result, new short[] {}));
+				assertEquals(0, result.getCardinality());
+			}
+		}
+	}
 
-    
-    
+	@Test
+	public void and2()
+	    throws InstantiationException, IllegalAccessException
+	{
+		System.out.println("and2");
+		for (Class ct : CONTAINER_TYPES)
+		{
+			Container ac = (Container) ct.newInstance();
+			ac.add((short) 1);
+			for (Class ct1 : CONTAINER_TYPES)
+			{
+				Container ac1 = (Container) ct1.newInstance();
+
+				ac1.add((short) 1);
+				ac1.add((short) 4);
+				ac1.add((short) 5);
+				ac1.add((short) 50000);
+				ac1.add((short) 50002);
+				ac1.add((short) 50003);
+				ac1.add((short) 50004);
+
+				Container result = ac.and(ac1);
+				assertTrue(checkContent(result, new short[] { 1 }));
+				assertEquals(result.getCardinality(), ac.andCardinality(ac1));
+				assertEquals(result.getCardinality(), ac1.andCardinality(ac));
+				assertEquals(1, ac1.andCardinality(ac));
+			}
+		}
+	}
+ 
+
+
+
+	@Test
+	public void and3()
+	    throws InstantiationException, IllegalAccessException
+	{
+		System.out.println("and3");
+		for (Class ct : CONTAINER_TYPES)
+		{
+			Container ac = (Container) ct.newInstance();
+
+			ac.add((short) 1);
+			ac.add((short) 3);
+			ac.add((short) 5);
+			ac.add((short) 50000);
+			ac.add((short) 50001);
+
+			// array ends first
+
+			for (Class ct1 : CONTAINER_TYPES)
+			{
+				Container ac1 = (Container) ct1.newInstance();
+
+				ac1.add((short) 1);
+				ac1.add((short) 4);
+				ac1.add((short) 5);
+				ac1.add((short) 50000);
+				ac1.add((short) 50002);
+				ac1.add((short) 50003);
+				ac1.add((short) 50004);
+
+				Container result = ac.and(ac1);
+				assertTrue(checkContent(result, new short[] { 1, 5, (short) 50000 }));
+				assertEquals(result.getCardinality(), ac.andCardinality(ac1));
+				assertEquals(result.getCardinality(), ac1.andCardinality(ac));
+				assertEquals(3, ac1.andCardinality(ac));
+			}
+		}
+	}
+  
+
+  
+	@Test
+	public void and4()
+	    throws InstantiationException, IllegalAccessException
+	{
+		System.out.println("and4");
+		for (Class ct : CONTAINER_TYPES)
+		{
+			Container ac = (Container) ct.newInstance();
+
+			ac.add((short) 1);
+			ac.add((short) 3);
+			ac.add((short) 5);
+			ac.add((short) 50000);
+			ac.add((short) 50001);
+			ac.add((short) 50011);
+
+			// iterator ends first
+
+			for (Class ct1 : CONTAINER_TYPES)
+			{
+				Container ac1 = (Container) ct1.newInstance();
+
+				ac1.add((short) 1);
+				ac1.add((short) 4);
+				ac1.add((short) 5);
+				ac1.add((short) 50000);
+				ac1.add((short) 50002);
+				ac1.add((short) 50003);
+				ac1.add((short) 50004);
+
+				Container result = ac.and(ac1);
+				assertTrue(checkContent(result, new short[] { 1, 5, (short) 50000 }));
+				assertEquals(result.getCardinality(), ac.andCardinality(ac1));
+				assertEquals(result.getCardinality(), ac1.andCardinality(ac));
+				assertEquals(3, ac1.andCardinality(ac));
+			}
+		}
+	}
+                
+
+
+	@Test
+	public void and5()
+	    throws InstantiationException, IllegalAccessException
+	{
+		System.out.println("and5");
+		for (Class ct : CONTAINER_TYPES)
+		{
+			Container ac = (Container) ct.newInstance();
+
+			ac.add((short) 1);
+			ac.add((short) 3);
+			ac.add((short) 5);
+			ac.add((short) 50000);
+			ac.add((short) 50001);
+
+			// end together
+
+			for (Class ct1 : CONTAINER_TYPES)
+			{
+				Container ac1 = (Container) ct1.newInstance();
+
+				ac1.add((short) 1);
+				ac1.add((short) 4);
+				ac1.add((short) 5);
+				ac1.add((short) 50000);
+				ac1.add((short) 50001);
+
+				Container result = ac.and(ac1);
+				assertTrue(checkContent(result, new short[] { 1, 5, (short) 50000, (short) 50001 }));
+				assertEquals(result.getCardinality(), ac.andCardinality(ac1));
+				assertEquals(result.getCardinality(), ac1.andCardinality(ac));
+				assertEquals(4, ac1.andCardinality(ac));
+			}
+		}
+	}
 }

--- a/src/test/java/org/roaringbitmap/TestContainer.java
+++ b/src/test/java/org/roaringbitmap/TestContainer.java
@@ -877,6 +877,8 @@ public class TestContainer {
 				Container result = ac.and(ac1);
 				assertTrue(checkContent(result, new short[] {}));
 				assertEquals(0, result.getCardinality());
+				assertEquals(0, ac.andCardinality(ac1));
+				assertEquals(0, ac1.andCardinality(ac));
 			}
 		}
 	}

--- a/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -2669,14 +2669,16 @@ public class TestRoaringBitmap {
         for (int N = 2; N < ewah.length; ++N) {
             RoaringBitmap answer = ewah[0];
             for (int k = 1; k < N; ++k)
-                answer = RoaringBitmap.and(answer, ewah[k]);
-
+            {
+            	RoaringBitmap oldAnswer = answer;
+                answer = RoaringBitmap.and(oldAnswer, ewah[k]);
+                Assert.assertEquals(answer.getCardinality(), RoaringBitmap.andCardinality(oldAnswer, ewah[k]));
+            }
             RoaringBitmap answer2 = FastAggregation.and(Arrays.copyOf(ewah, N));
             Assert.assertTrue(answer.equals(answer2));
             RoaringBitmap answer2b = FastAggregation.and(toIterator(Arrays
                     .copyOf(ewah, N)));
             Assert.assertTrue(answer.equals(answer2b));
-
         }
     }
 


### PR DESCRIPTION
Hi this is the code to do the andCardinality without materializing the Containers. Which should be even faster. Again my apologies for messing up the code formatting. Hope this is useful.Before pulling could you have a look at the test cases to see if they make sense. I pulled them out of the or tests and added all against all container tests. Reading from the comments I think it does  a decent job of covering most possibilities. 