### PR TITLE
fix bug in flip() of ImmutableRoaringBitmap

### DIFF
--- a/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -220,7 +220,7 @@ public class ImmutableRoaringBitmap implements Iterable<Integer>, Cloneable, Imm
             if (i >= 0) {
                 final MappeableContainer c = bm.highLowContainer
                         .getContainerAtIndex(i).not(containerStart,
-                                containerLast);
+                                containerLast+1);
                 if (c.getCardinality() > 0)
                     answer.getMappeableRoaringArray().insertNewKeyValueAt(
                             -j - 1, hb, c);

--- a/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Assert;
 import org.junit.Test;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 
 import java.io.*;
 import java.util.*;
@@ -1883,6 +1884,20 @@ public class TestRoaringBitmap {
             bs.set(i);
         Assert.assertTrue(equals(bs, rb2));
     }
+
+    @Test
+    public void flipTest8()
+    {
+        final RoaringBitmap rb = new RoaringBitmap();
+        rb.add(0);
+        rb.add(2);
+        final RoaringBitmap rb2 = RoaringBitmap.flip(rb, 0, 3);
+
+        final BitSet bs = new BitSet();
+        bs.set(1);
+        Assert.assertTrue(equals(bs, rb2));
+    }
+
 
     @Test
     public void flipTestBig() {

--- a/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
+++ b/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
@@ -769,4 +769,29 @@ public class TestImmutableRoaringBitmap {
         rb2.andNot(rb);
         Assert.assertEquals(rb2, off);
     }
+
+  @Test
+  public void fliptest1() {
+    final MutableRoaringBitmap rb = new MutableRoaringBitmap();
+    rb.add(0);
+    rb.add(2);
+    final MutableRoaringBitmap rb2 = MutableRoaringBitmap.flip(rb, 0, 3);
+    final MutableRoaringBitmap result = new MutableRoaringBitmap();
+    result.add(1);
+
+    Assert.assertEquals(result, rb2);
+  }
+
+  @Test
+  public void fliptest2() {
+    final MutableRoaringBitmap rb = new MutableRoaringBitmap();
+    rb.add(0);
+    rb.add(2);
+    final MutableRoaringBitmap rb2 = ImmutableRoaringBitmap.flip(rb, 0, 3);
+    final MutableRoaringBitmap result = new MutableRoaringBitmap();
+    result.add(1);
+
+    Assert.assertEquals(result, rb2);
+  }
+
 }


### PR DESCRIPTION
Simple fix.
Make flip() of ImmutableRoaringBitmap is consistent with those of MutableRoaringBitmap and RoaringBitmap.

This PR fix #61 